### PR TITLE
Add support for Oracle Java 8's Nashorn JavaScript Interpreter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,25 @@ python:
   - "3.4"
 
 env:
- - "SLIMERJSLAUNCHER=$(which firefox) DISPLAY=:99.0 PATH=$TRAVIS_BUILD_DIR/slimerjs:$PATH"
+  global:
+    - "SLIMERJSLAUNCHER=$(which firefox)"
+    - "DISPLAY=:99.0"
+    - "PATH=$TRAVIS_BUILD_DIR/slimerjs:$PATH"
+
+matrix:
+  include:
+    - python: "2.7"
+      env: JDK=oracle8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
+    - python: "3.4"
+      env: JDK=oracle8
+      addons:
+        apt:
+          packages:
+            - oracle-java8-installer
 
 before_script:
   - "sh -e /etc/init.d/xvfb start"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ PyExecJS supports these runtimes:
 * [Microsoft Windows Script Host](http://msdn.microsoft.com/en-us/library/9bbdkx3k.aspx) (JScript)
 * [SlimerJS](http://slimerjs.org/)
 * [PhantomJS](http://phantomjs.org/)
+* [Nashorn](http://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/intro.html#sthref16) - Included with Oracle Java 8
 
 
 If `EXECJS_RUNTIME` environment variable is specified, PyExecJS pick the JavaScript runtime as a default:

--- a/README.rst
+++ b/README.rst
@@ -60,13 +60,15 @@ PyExecJS supports these runtimes:
    (JScript)
 -  `SlimerJS <http://slimerjs.org/>`__
 -  `PhantomJS <http://phantomjs.org/>`__
+-  `Nashorn <http://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/intro.html#sthref16>`__
+   - Included with Oracle Java 8
 
 If ``EXECJS_RUNTIME`` environment variable is specified, PyExecJS pick
 the JavaScript runtime as a default:
 
 ::
 
-    >>> #execjs.get().name # this value is depends on your environment.
+    >>> execjs.get().name # this value is depends on your environment.
     >>> os.environ["EXECJS_RUNTIME"] = "Node"
     >>> execjs.get().name
     'Node.js (V8)'

--- a/execjs/__init__.py
+++ b/execjs/__init__.py
@@ -577,3 +577,28 @@ for _name, _command in [
 });
 phantom.exit();
 """)
+
+_runtimes['JavaJavaScript'] = ExternalRuntime(
+    name="JavaJavaScript",
+    command=["jrunscript"],
+    runner_source=r"""(function(program, execJS) { execJS(program) })(function() { #{source}
+}, function(program) {
+  #{json2_source}
+  var output;
+  try {
+    result = program();
+    print("");
+    if (typeof result == 'undefined' && result !== null) {
+      print('["ok"]');
+    } else {
+      try {
+        print(JSON.stringify(['ok', result]));
+      } catch (err) {
+        print('["err"]');
+      }
+    }
+  } catch (err) {
+    print(JSON.stringify(['err', '' + err]));
+  }
+});
+""")

--- a/execjs/__init__.py
+++ b/execjs/__init__.py
@@ -580,7 +580,7 @@ phantom.exit();
 
 _runtimes['JavaJavaScript'] = ExternalRuntime(
     name="JavaJavaScript",
-    command=["jrunscript"],
+    command=["jjs"],
     runner_source=r"""(function(program, execJS) { execJS(program) })(function() { #{source}
 }, function(program) {
   #{json2_source}


### PR DESCRIPTION
Oracle Java 8 comes with a bundled JavaScript interpreter named [Nashorn](http://docs.oracle.com/javase/8/docs/technotes/guides/scripting/nashorn/intro.html#sthref16) that can be invoked directly from the command line. This PR adds it as a supported runtime. This is useful on Linux where you may have Java installed, but note Node.JS.