### PR TITLE
calling javascript executable using stdin/pipes instead of temp directory

### DIFF
--- a/execjs/_external_runtime.py
+++ b/execjs/_external_runtime.py
@@ -116,7 +116,7 @@ class ExternalRuntime(AbstractRuntime):
             return runner_source
 
         def _extract_result(self, output):
-            output = output.decode(self._runtime._encoding)
+            # output = output.decode(self._runtime._encoding)
             output = output.replace("\r\n", "\n").replace("\r", "\n")
             output_last_line = output.split("\n")[-2]
 


### PR DESCRIPTION
The node binary executable performs `require(x)` commands using relative directory resolution. The previous temporary file approach would confuse this path resolution, thus making the `require('react')` call fail ('module not found').
Here we change the `_execfile` method to instead take source code and pipe it to the javascript binary in question. This approach allows the `cwd` argument to be respected.

Code snippet that used to fail, and now works (provided that you run this code from a directory where `npm install react` was run prior):

```python
import execjs
default = execjs.get("Node")
default = default.compile("""
var React = require('react')
""", cwd="./web")
default.eval("React.createElement('div', {className:'text-muted'}, '')")
```